### PR TITLE
Add new base.join_error_password_not_matching error case.

### DIFF
--- a/ow_static/plugins/base/js/base_field_validators.js
+++ b/ow_static/plugins/base/js/base_field_validators.js
@@ -182,7 +182,7 @@ var OW_BaseFieldValidators = function($params, $emailPattern, $usernamePattern)
             }
             else if ( password.val() !== passwordRepeat.val() & passwordRepeat.val().length > 0 )
             {
-                self.errors['password']['error'] = OW.getLanguageText('base', 'join_error_password_not_valid');
+                self.errors['password']['error'] = OW.getLanguageText('base', 'join_error_password_not_matching');
                 return false;
             }
 

--- a/ow_system_plugins/base/classes/password_validator.php
+++ b/ow_system_plugins/base/classes/password_validator.php
@@ -61,7 +61,7 @@ abstract class BASE_CLASS_PasswordValidator extends OW_Validator
         }
         else if ( isset($_POST['repeatPassword']) && $value !== $_POST['repeatPassword'] )
         {
-            $this->setErrorMessage($language->text('base', 'join_error_password_not_valid'));
+            $this->setErrorMessage($language->text('base', 'join_error_password_not_matching'));
             return false;
         }
 

--- a/ow_system_plugins/base/components/change_password.php
+++ b/ow_system_plugins/base/components/change_password.php
@@ -113,6 +113,7 @@ class BASE_CMP_ChangePassword extends OW_Component
             $language->addKeyForJs('base', 'join_error_password_not_valid');
             $language->addKeyForJs('base', 'join_error_password_too_short');
             $language->addKeyForJs('base', 'join_error_password_too_long');
+            $language->addKeyForJs('base', 'join_error_password_not_matching');
 
             //include js
             $onLoadJs = " window.changePassword = new OW_BaseFieldValidators( " .

--- a/ow_system_plugins/base/controllers/complete_profile.php
+++ b/ow_system_plugins/base/controllers/complete_profile.php
@@ -187,6 +187,7 @@ class BASE_CTRL_CompleteProfile extends OW_ActionController
         $language->addKeyForJs('base', 'join_error_password_not_valid');
         $language->addKeyForJs('base', 'join_error_password_too_short');
         $language->addKeyForJs('base', 'join_error_password_too_long');
+        $language->addKeyForJs('base', 'join_error_password_not_matching');
 
         //include js
         $onLoadJs = " window.edit = new OW_BaseFieldValidators( " .

--- a/ow_system_plugins/base/controllers/edit.php
+++ b/ow_system_plugins/base/controllers/edit.php
@@ -297,6 +297,7 @@ class BASE_CTRL_Edit extends OW_ActionController
         $language->addKeyForJs('base', 'join_error_password_not_valid');
         $language->addKeyForJs('base', 'join_error_password_too_short');
         $language->addKeyForJs('base', 'join_error_password_too_long');
+        $language->addKeyForJs('base', 'join_error_password_not_matching');
 
         //include js
         $onLoadJs = " window.edit = new OW_BaseFieldValidators( " .

--- a/ow_system_plugins/base/controllers/join.php
+++ b/ow_system_plugins/base/controllers/join.php
@@ -102,6 +102,7 @@ class BASE_CTRL_Join extends OW_ActionController
         $language->addKeyForJs('base', 'join_error_password_not_valid');
         $language->addKeyForJs('base', 'join_error_password_too_short');
         $language->addKeyForJs('base', 'join_error_password_too_long');
+        $language->addKeyForJs('base', 'join_error_password_not_matching');
 
         //include js
         $onLoadJs = " window.join = new OW_BaseFieldValidators( " .


### PR DESCRIPTION
The "valid password" error (especially when it is shown below the first password field) can be confusing. This adds a specific error message. (change_password has one already).