### PR TITLE
Allow larger passwords typically used by PW safes.

### DIFF
--- a/ow_utilities/validator.php
+++ b/ow_utilities/validator.php
@@ -31,7 +31,7 @@ class UTIL_Validator
 {
     const PASSWORD_MIN_LENGTH = 4;
 
-    const PASSWORD_MAX_LENGTH = 15;
+    const PASSWORD_MAX_LENGTH = 128;
 
     const USER_NAME_PATTERN = '/^[\w]{1,32}$/';
 


### PR DESCRIPTION
 PW is stored as a hash, limit does not matter.

I would also increase the minlength to 6, but I fugured the PR should be seperate?