### PR TITLE
Encrypt site password with API

### DIFF
--- a/ow_system_plugins/admin/controllers/permissions.php
+++ b/ow_system_plugins/admin/controllers/permissions.php
@@ -40,6 +40,8 @@ class ADMIN_CTRL_Permissions extends ADMIN_CTRL_Abstract
     public function __construct()
     {
         parent::__construct();
+        
+        require_once OW_DIR_LIB . 'password_compat' . DS . 'password.php';
 
         $this->setPageHeading(OW::getLanguage()->text('admin', 'permissions_page_heading'));
         $this->setPageHeadingIconClass('ow_ic_lock');
@@ -112,9 +114,8 @@ class ADMIN_CTRL_Permissions extends ADMIN_CTRL_Abstract
                 }
                 else
                 {
-                    $data['password'] = crypt($data['password'], OW_PASSWORD_SALT);
                     $config->saveConfig('base', 'guests_can_view', (int) $data['guests_can_view']);
-                    $config->saveConfig('base', 'guests_can_view_password', $data['password']);
+                    $config->saveConfig('base', 'guests_can_view_password', password_hash($data['password'].OW_PASSWORD_SALT, PASSWORD_DEFAULT));
                 }
 
                 OW::getFeedback()->info($language->text('admin', 'permission_global_privacy_settings_success_message'));

--- a/ow_system_plugins/base/controllers/base_document.php
+++ b/ow_system_plugins/base/controllers/base_document.php
@@ -29,6 +29,13 @@
  */
 class BASE_CTRL_BaseDocument extends OW_ActionController
 {
+    
+    public function __construct()
+    {
+        parent::__construct();
+        
+        require_once OW_DIR_LIB . 'password_compat' . DS . 'password.php';
+    }
 
     public function index()
     {
@@ -132,9 +139,8 @@ class BASE_CTRL_BaseDocument extends OW_ActionController
         {
             $data = $form->getValues();
             $password = OW::getConfig()->getValue('base', 'guests_can_view_password');
-            $data['password'] = crypt($data['password'], OW_PASSWORD_SALT);
 
-            if ( !empty($data['password']) && $data['password'] === $password )
+            if ( !empty($data['password']) && password_verify($data['password'].OW_PASSWORD_SALT, $password) )
             {
                 setcookie('base_password_protection', UTIL_String::getRandomString(), (time() + 86400 * 30), '/');
                 echo "OW.info('" . OW::getLanguage()->text('base', 'password_protection_success_message') . "');window.location.reload();";


### PR DESCRIPTION
Hash site password with compatibility library with PHP 5.5's simplified password hashing API.
With 'password_verify' function in oxwall/oxwall#156 password is checked for accordance on input.