### PR TITLE
Verify site password with API

### DIFF
--- a/ow_system_plugins/base/controllers/base_document.php
+++ b/ow_system_plugins/base/controllers/base_document.php
@@ -29,6 +29,12 @@
  */
 class BASE_CTRL_BaseDocument extends OW_ActionController
 {
+    public function __construct()
+    {
+        parent::__construct();
+        
+        require_once OW_DIR_LIB . 'password_compat' . DS . 'password.php';
+    }
 
     public function index()
     {
@@ -132,9 +138,8 @@ class BASE_CTRL_BaseDocument extends OW_ActionController
         {
             $data = $form->getValues();
             $password = OW::getConfig()->getValue('base', 'guests_can_view_password');
-            $data['password'] = crypt($data['password'], OW_PASSWORD_SALT);
 
-            if ( !empty($data['password']) && $data['password'] === $password )
+            if ( !empty($data['password']) && password_verify($data['password'].OW_PASSWORD_SALT, $password) )
             {
                 setcookie('base_password_protection', UTIL_String::getRandomString(), (time() + 86400 * 30), '/');
                 echo "OW.info('" . OW::getLanguage()->text('base', 'password_protection_success_message') . "');window.location.reload();";


### PR DESCRIPTION
Verify site password with compatibility library with PHP 5.5's simplified password hashing API on input. Password is hashed with 'password_hash' function in oxwall/oxwall#155.