### PR TITLE
Change RegExp

### DIFF
--- a/ow_utilities/validator.php
+++ b/ow_utilities/validator.php
@@ -33,7 +33,7 @@ class UTIL_Validator
 
     const PASSWORD_MAX_LENGTH = 128;
 
-    const USER_NAME_PATTERN = '/^[\w]{1,32}$/';
+    const USER_NAME_PATTERN = '/^[\p{L}\p{N}\p{Z}]{1,32}$/';
 
     const EMAIL_PATTERN = '/^([\w\-\.\+\%]*[\w])@((?:[A-Za-z0-9\-]+\.)+[A-Za-z]{2,})$/';
 


### PR DESCRIPTION
Allow any kind of letter from any language, any kind of whitespace or invisible separator and any kind of numeric character to support international usernames. Whitespaces are added to support usernames that consists in two parts, such as "John Doe" in order to be able to enter first and last name. In this way, username and realname fields are not needed anymore.