### PR TITLE
Fix for use custom decorators in Submit.

### DIFF
--- a/ow_core/form_element.php
+++ b/ow_core/form_element.php
@@ -990,7 +990,7 @@ class Submit extends FormElement
 
         if ( $this->decorator !== false )
         {
-            $finalMarkup = OW::getThemeManager()->processDecorator('button', $params);
+            $finalMarkup = OW::getThemeManager()->processDecorator($this->decorator, $params);
         }
         else
         {


### PR DESCRIPTION
Submit has feature for custom decorators from constructor. By default use only 'button' decorator. This is error.