### PR TITLE
remove ZipArchive::addEmptyDir

### DIFF
--- a/ow_system_plugins/admin/controllers/languages.php
+++ b/ow_system_plugins/admin/controllers/languages.php
@@ -688,7 +688,7 @@ class ADMIN_CTRL_Languages extends ADMIN_CTRL_Abstract
 
                 //$langDir = 'langs' . DS . $langDto->getTag() . DS;
                 $langDir = "language_{$langDto->getTag()}" . DS;
-                $za->addEmptyDir($langDir);
+                //$za->addEmptyDir($langDir);
 
                 $dir = "{$languageService->getExportDirPath()}{$langDir}";
 


### PR DESCRIPTION
addEmptyDir creates null sized file with empty name inside archive, this causes problems with OW::getLanguage()->importPluginLangs() preventing language pack from being imported. 
I think we can safely remove ZipArchive::addEmptyDir() from controller, because ZipArchive::addFile() already creates all necessary subdirectories

tested on PHP v5.6 Win