### PR TITLE
Change access level of singleton constructor to `protected`.

### DIFF
--- a/ow_core/singleton.php
+++ b/ow_core/singleton.php
@@ -21,7 +21,7 @@ trait OW_Singleton
         return static::$instance;
     }
 
-    private function __construct()
+    protected function __construct()
     {
     }
 }


### PR DESCRIPTION
At the moment, `OW_Singleton` trait adds a `private` constructor. I suggest to change the access level of the method to `protected`. It will add possibility to override the method in children which will be created by `OW::getClassInstance`.