### PR TITLE
Correct `No values` situation on language edit page

### DIFF
--- a/ow_system_plugins/admin/views/controllers/languages_index.html
+++ b/ow_system_plugins/admin/views/controllers/languages_index.html
@@ -74,7 +74,7 @@ $(function(){
             	{if $list|@count == 0}
 		           	<div class="ow_anno ow_std_margin">
 		               <div style="text-align:center;">
-		               		{ text key="admin+no_values" } 
+		               		{text key="admin+no_values"}
 		               	</div>
 		            </div>
             	{/if}


### PR DESCRIPTION
This change fixes the issue when this message `{ text key="admin+no_values" }` was displayed instead of this `No values`.

The issue appeared on:
`/admin/settings/dev-tools/languages?&prefix=[a new prefix with no values]`