### PR TITLE
Tagline _probably_ shouldn't be required.

### DIFF
--- a/ow_system_plugins/admin/controllers/settings.php
+++ b/ow_system_plugins/admin/controllers/settings.php
@@ -574,7 +574,7 @@ class ConfigSaveForm extends Form
         $this->addElement($siteEmailField);
 
         $taglineField = new TextField('tagline');
-        $taglineField->setRequired(true);
+        //$taglineField->setRequired(true);
         $this->addElement($taglineField);
 
         $descriptionField = new Textarea('description');


### PR DESCRIPTION
During initial setup, a tagline isn't required for the site, however,
during editing, it suddenly becomes required. Whether or not it's
required should be the same for consistency reasons, obviously, and I
assumed that "not required" was the appropriate change.