### PR TITLE
Fixed IDE error for wrong PHPDoc line

### DIFF
--- a/ow_core/storage.php
+++ b/ow_core/storage.php
@@ -25,7 +25,6 @@
 /**
  * @author Podyachev Evgeny <joker.OW2@gmail.com>
  * @package ow_core
- * @method static OW_Storage getInstance()
  * @since 1.0
  */
 


### PR DESCRIPTION
Hi Oxwall,
The removed line in this PR is a wrong PHPDoc note. It's not implemented by any of the implements of this class, such as UPDATE_AmazonCloudStorage. The alternative is to implement and use this function in all of the four implements of this class, but it will have other effects on other classes which use these classes.
I noticed this by following my IDE errors.
@esase 