### PR TITLE
Security Fix: CVE-2022-25128

### DIFF
--- a/ow_system_plugins/base/controllers/base_document.php
+++ b/ow_system_plugins/base/controllers/base_document.php
@@ -52,8 +52,8 @@ class BASE_CTRL_BaseDocument extends OW_ActionController
         OW::getDocument()->getMasterPage()->setTemplate(OW::getThemeManager()->getMasterPageTemplate(OW_MasterPage::TEMPLATE_BLANK));
         $this->assign('text', OW::getSession()->get('baseConfirmPageMessage'));
         OW::getSession()->delete('baseConfirmPageMessage');
-        $this->assign('okBackUrl', OW::getRequest()->buildUrlQueryString(OW_URL_HOME . urldecode($_GET['back_uri']), array('confirm-result' => 1)));
-        $this->assign('clBackUrl', OW::getRequest()->buildUrlQueryString(OW_URL_HOME . urldecode($_GET['back_uri']), array('confirm-result' => 0)));
+        $this->assign('okBackUrl', OW::getRequest()->buildUrlQueryString(OW_URL_HOME . urlencode($_GET['back_uri']), array('confirm-result' => 1)));
+        $this->assign('clBackUrl', OW::getRequest()->buildUrlQueryString(OW_URL_HOME . urlencode($_GET['back_uri']), array('confirm-result' => 0)));
     }
 
     public function page404()


### PR DESCRIPTION
Hi!

This commit will patch the CVE-2022-25128 vulnerability (XSS).
I asked "Skadate" to provide an update for Free users, but they didn't respond.

Also, about CVE-2021-36593, CVE-2021-36594, CVE-2021-36596, CVE-2021-36597, CVE-2021-36598, CVE-2021-36599, months ago, I asked to provide an update for free users, but unfortunately, the latest version in "https://storage.oxwall.org/platform-info" is 1.8.4 (Build 10800), and the version is vulnerable.

Some of these vulnerabilities are Pre-Auth RCE (Unauthenticated Remote Code Execution) and are very dangerous.

Please provide an update!

Thank you!

Good luck!