### PR TITLE
admin user search by realname bugs and errors

### DIFF
--- a/ow_system_plugins/base/bol/user_dao.php
+++ b/ow_system_plugins/base/bol/user_dao.php
@@ -947,7 +947,7 @@ class BOL_UserDao extends OW_BaseDao
                     return;
                 }
                 
-                $result = " LCASE(`" . $prefix . "`.`textValue`) LIKE '" . $this->dbo->escapeString(strtolower($value)) . "%'";
+                $result = " (LCASE(`" . $prefix . "`.`textValue`) LIKE '" . $this->dbo->escapeString(strtolower($value)) . "%' OR LCASE(`" . $prefix . "`.`textValue`) LIKE '%" . $this->dbo->escapeString(strtolower($value)) . "')";
                 break;
 
             case BOL_QuestionService::QUESTION_PRESENTATION_CHECKBOX :

--- a/ow_system_plugins/base/bol/user_dao.php
+++ b/ow_system_plugins/base/bol/user_dao.php
@@ -947,7 +947,7 @@ class BOL_UserDao extends OW_BaseDao
                     return;
                 }
                 
-                $result = " (LCASE(`" . $prefix . "`.`textValue`) LIKE '" . $this->dbo->escapeString(strtolower($value)) . "%' OR LCASE(`" . $prefix . "`.`textValue`) LIKE '%" . $this->dbo->escapeString(strtolower($value)) . "')";
+                $result = " (LCASE(`" . $prefix . "`.`textValue`) LIKE '" . $this->dbo->escapeString(mb_strtolower($value)) . "%' OR LCASE(`" . $prefix . "`.`textValue`) LIKE '%" . $this->dbo->escapeString(mb_strtolower($value)) . "')";
                 break;
 
             case BOL_QuestionService::QUESTION_PRESENTATION_CHECKBOX :


### PR DESCRIPTION
Matching users with multiple words in their realname. Currently only first word will get matched.

Fixing "Illegal mix of collations" error in mysql when passing some none utf8 chars like words with accents.