### PR TITLE
!!!Security Vulnerability. Logged-out users can upload images!!!!

### DIFF
--- a/ow_system_plugins/base/controllers/avatar.php
+++ b/ow_system_plugins/base/controllers/avatar.php
@@ -55,6 +55,12 @@ class BASE_CTRL_Avatar extends OW_ActionController
      */
     public function ajaxResponder()
     {
+
+if (!OW::getUser()->isAuthenticated()) 
+{
+throw new AuthenticateException();
+}
+        
         $request = $_POST;
 
         if ( isset($request['ajaxFunc']) && OW::getRequest()->isAjax() )


### PR DESCRIPTION
Allows none logged in users upload images. For the security purposes can't post any hints on how to replicate this exploit. But if any one the moderators interested I can share the code.

Update!!!

Looks like this is part of the join image upload!!!

However I would like to maybe add more checks like if the function to upload avatar is ON or OFF. 

However in my ayes this compromises security and should be discontinued. 

How many reputable websites allow guests upload their pics before signup. A handful or none.