### PR TITLE
Restrict access to email-verify-form

### DIFF
--- a/ow_system_plugins/base/controllers/email_verify.php
+++ b/ow_system_plugins/base/controllers/email_verify.php
@@ -133,6 +133,21 @@ class BASE_CTRL_EmailVerify extends OW_ActionController
     public function verifyForm( $params )
     {
         $this->setMasterPage();
+
+        $userId = OW::getUser()->getId();
+
+        if ( OW::getUser()->isAuthenticated() || $userId === null )
+        {
+            throw new Redirect403Exception();
+        }
+
+        $user = BOL_UserService::getInstance()->findUserById($userId);
+
+        if ( (int) $user->emailVerify === 1 )
+        {
+            throw new Redirect403Exception();
+        }
+        
         $language = OW::getLanguage();
 
         $this->setPageHeading($language->text('base', 'email_verify_index'));

--- a/ow_system_plugins/base/controllers/email_verify.php
+++ b/ow_system_plugins/base/controllers/email_verify.php
@@ -134,16 +134,7 @@ class BASE_CTRL_EmailVerify extends OW_ActionController
     {
         $this->setMasterPage();
 
-        $userId = OW::getUser()->getId();
-
-        if ( OW::getUser()->isAuthenticated() || $userId === null )
-        {
-            throw new Redirect403Exception();
-        }
-
-        $user = BOL_UserService::getInstance()->findUserById($userId);
-
-        if ( (int) $user->emailVerify === 1 )
+        if ( OW::getUser()->isAuthenticated())
         {
             throw new Redirect403Exception();
         }


### PR DESCRIPTION
Only guests can access email-verify-form. Logged in and unverified users will be redirected to email verify controller anyways.