### PR TITLE
Captcha BUG

### DIFF
--- a/ow_core/validator.php
+++ b/ow_core/validator.php
@@ -1303,6 +1303,7 @@ class CaptchaValidator extends OW_Validator
                     return false;
                 }
             }
+            OW::getSession()->set('securimage_code_value', ''); //BUG prevent-reuse
             return true;
         }
         else


### PR DESCRIPTION
Prevent captcha from being validated multiple times. This is specially problematic when using ajax form.

PS. On ajaxForm validation use:

```
$ajaxForm = new classGetMyAjaxForm();
$ajaxForm ->isValid($_POST);
```

OR

If you don't have a form class then use:

```
$captchaValidatior = new CaptchaValidator();

if(!$captchaValidatior->isValid($_POST['captcha']))
{
exit(json_encode(['response'=>'error','msg'=>'Captcha not valid']));
}
```