### PR TITLE
Secure csrf_tokens

### DIFF
--- a/ow_utilities/csrf.php
+++ b/ow_utilities/csrf.php
@@ -71,8 +71,8 @@ class UTIL_Csrf
 
 // do not set validation limit. Exp: 3 seconds as in many cases token gets validated by multiple classes it take milliseconds which will make it fail
 
-    // delete by validation count
-    if (isset($tokenData['isValidCount']) && $tokenData['isValidCount'] >= 10) {
+    // delete by validation count. Keep count_limit relativelly high but not too high. =>50 and =<100
+    if (isset($tokenData['isValidCount']) && $tokenData['isValidCount'] >= 50) {
         unset($tokenList[$token]);
         self::saveTokenList($tokenList);
         return false;

--- a/ow_utilities/csrf.php
+++ b/ow_utilities/csrf.php
@@ -69,10 +69,7 @@ class UTIL_Csrf
         return false;
     }
 
-    // set validation limit (3 seconds between uses)
-    if (isset($tokenData['lastValidateTime']) && $tokenData['lastValidateTime'] > strtotime('-3 seconds')) {
-        return false;
-    }
+// do not set validation limit. Exp: 3 seconds as in many cases token gets validated by multiple classes it take milliseconds which will make it fail
 
     // delete by validation count
     if (isset($tokenData['isValidCount']) && $tokenData['isValidCount'] >= 10) {

--- a/ow_utilities/csrf.php
+++ b/ow_utilities/csrf.php
@@ -40,7 +40,7 @@ class UTIL_Csrf
     {
         $tokenList = self::getTokenList();
         $token = base64_encode(time() . UTIL_String::getRandomString(32));
-        $tokenList[$token] = time();
+        $tokenList[$token] = ['createTime'=>time(),'lastValidateTime'=>0,'isValidCount'=>0];
         self::saveTokenList($tokenList);
 
         return $token;

--- a/ow_utilities/csrf.php
+++ b/ow_utilities/csrf.php
@@ -52,12 +52,43 @@ class UTIL_Csrf
      * @param string $token
      * @return bool
      */
-    public static function isTokenValid( $token )
-    {
-        $tokenList = self::getTokenList();
+    public static function isTokenValid($token)
+{
+    $tokenList = self::getTokenList();
 
-        return !empty($tokenList[$token]);
+    if (!isset($tokenList[$token])) {
+        return false;
     }
+
+    $tokenData = $tokenList[$token];
+
+    // delete expired (10 minuted old)
+    if (isset($tokenData['createTime']) && $tokenData['createTime'] < strtotime('-10 minutes')) {
+        unset($tokenList[$token]);
+        self::saveTokenList($tokenList);
+        return false;
+    }
+
+    // set validation limit (3 seconds between uses)
+    if (isset($tokenData['lastValidateTime']) && $tokenData['lastValidateTime'] > strtotime('-3 seconds')) {
+        return false;
+    }
+
+    // delete by validation count
+    if (isset($tokenData['isValidCount']) && $tokenData['isValidCount'] >= 10) {
+        unset($tokenList[$token]);
+        self::saveTokenList($tokenList);
+        return false;
+    }
+
+    // update values
+    $tokenData['lastValidateTime'] = time();
+    $tokenData['isValidCount'] = isset($tokenData['isValidCount']) ? $tokenData['isValidCount'] + 1 : 1;
+    $tokenList[$token] = $tokenData;
+    self::saveTokenList($tokenList);
+
+    return true;
+}
     /* -------------------------------------------------------------------------------------------------------------- */
 
     private static function getTokenList()


### PR DESCRIPTION
Expire by time, validation count and set validation limit. Currently as long as you use same session you can reuse same csrf_token over and over again. This update takes care of it.